### PR TITLE
Move from IvoryCKEditorBundle to FOSCKEditorBundle

### DIFF
--- a/Resources/doc/README_EN.md
+++ b/Resources/doc/README_EN.md
@@ -55,7 +55,7 @@ Documentation
 - Filter using        [LexikFormFilterBundle](https://github.com/lexik/LexikFormFilterBundle) .
 - Form datetime type  [DatetimepickerBundle](https://github.com/stephanecollot/DatetimepickerBundle) .
 - Uploads files       [VichUploaderBundle](https://github.com/dustin10/VichUploaderBundle) .
-- Text editor         [IvoryCKEditorBundle](https://github.com/egeloen/IvoryCKEditorBundle) .
+- Text editor         [FOSCKEditorBundle](https://github.com/FriendsOfSymfony/FOSCKEditorBundle) .
 - Image manipulation  [LiipImagineBundle](https://github.com/liip/LiipImagineBundle) .
 - Twig Extensions     [TwigExtensions](http://twig.sensiolabs.org/doc/extensions/intl.html) .
 - Select 2 Entity     [select2entity-bundle](https://github.com/tetranz/select2entity-bundle) .

--- a/Resources/doc/forms.md
+++ b/Resources/doc/forms.md
@@ -56,9 +56,9 @@ use MWSimple\Bundle\AdminCrudBundle\Form\Type\FormrowType;
 ```cli
 php bin/console assets:install
 ```
-#### Campo CKEditorType::class [Documentación](http://symfony.com/doc/master/bundles/IvoryCKEditorBundle/index.html). Ejemplo
+#### Campo CKEditorType::class [Documentación](http://symfony.com/doc/master/bundles/FOSCKEditorBundle/index.html). Ejemplo
 ```php
-use Ivory\CKEditorBundle\Form\Type\CKEditorType;
+use FOS\CKEditorBundle\Form\Type\CKEditorType;
 
 $builder
     ->add('field', CKEditorType::class, array(

--- a/Resources/doc/forms_en.md
+++ b/Resources/doc/forms_en.md
@@ -56,9 +56,9 @@ use MWSimple\Bundle\AdminCrudBundle\Form\Type\FormrowType;
 ```cli
 php bin/console assets:install
 ```
-#### Field CKEditorType::class [Documentation](http://symfony.com/doc/master/bundles/IvoryCKEditorBundle/index.html). Example
+#### Field CKEditorType::class [Documentation](http://symfony.com/doc/master/bundles/FOSCKEditorBundle/index.html). Example
 ```php
-use Ivory\CKEditorBundle\Form\Type\CKEditorType;
+use FOS\CKEditorBundle\Form\Type\CKEditorType;
 
 $builder
     ->add('field', CKEditorType::class, array(

--- a/Resources/doc/instalacion.md
+++ b/Resources/doc/instalacion.md
@@ -18,11 +18,11 @@ new SC\DatetimepickerBundle\SCDatetimepickerBundle(),
 new Liip\ImagineBundle\LiipImagineBundle(),
 new Tetranz\Select2EntityBundle\TetranzSelect2EntityBundle(),
 new Vich\UploaderBundle\VichUploaderBundle(),
-// new Ivory\CKEditorBundle\IvoryCKEditorBundle(),
+// new FOS\CKEditorBundle\FOSCKEditorBundle(),
 ```
 
 #### Para instanciar VichUploaderBundle descomentar y Ver: [Subiendo archivos](subirarchivos.md)
-#### Para instanciar IvoryCKEditorBundle descomentar y Ver: [Formularios Editor de texto](forms.md)
+#### Para instanciar FOSCKEditorBundle descomentar y Ver: [Formularios Editor de texto](forms.md)
 
 ### Importar configuración y permitir traducciones (incluye en_US, es_AR, ca_ES, pt_BR, fr, pl)
 

--- a/Resources/doc/instalacion_en.md
+++ b/Resources/doc/instalacion_en.md
@@ -18,11 +18,11 @@ new SC\DatetimepickerBundle\SCDatetimepickerBundle(),
 new Liip\ImagineBundle\LiipImagineBundle(),
 new Tetranz\Select2EntityBundle\TetranzSelect2EntityBundle(),
 new Vich\UploaderBundle\VichUploaderBundle(),
-// new Ivory\CKEditorBundle\IvoryCKEditorBundle(),
+// new FOS\CKEditorBundle\FOSCKEditorBundle(),
 ```
 
 #### For instance VichUploaderBundle uncomment and View: [Uploads files](subirarchivos_en.md)
-#### For instance IvoryCKEditorBundle uncomment and View: [Forms Text editor](forms_en.md)
+#### For instance FOSCKEditorBundle uncomment and View: [Forms Text editor](forms_en.md)
 
 ### Configure imports config and translations (include en_US, es_AR, ca_ES, pt_BR, fr, pl)
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "mwsimple/scdatetimepicker-bundle": "^2.0",
         "liip/imagine-bundle": "^1.5",
         "vich/uploader-bundle": "^1.1",
-        "egeloen/ckeditor-bundle": "^6.0",
+        "friendsofsymfony/ckeditor-bundle": "dev-master",
         "tetranz/select2entity-bundle": "^2.9"
     },
     "config": {


### PR DESCRIPTION
Hi,

We took over [IvoryCKEditorBundle](https://github.com/egeloen/IvoryCKEditorBundle) and now it is under [FriendsOfSymfony](https://github.com/FriendsOfSymfony) wing and it is renamed to [FOSCKEditorBundle](https://github.com/FriendsOfSymfony/FOSCKEditorBundle).

We are helping active libraries that are depending on `IvoryCKEditorBundle` migrate to `FOSCKEditorBundle`.

The Bundle will be released in the next few days, do not merge until the bundle gets released so we can change the version in the composer.

Thank you for your time.